### PR TITLE
Use Hostname As ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ These variables are used by the service startup scripts in the Docker images, bu
 * `RECORDING_UNPUBLISH_DIR`: Directory where unpublished recording files are placed to make them unavailable to the web server. Defaults to `/var/bigbluebutton/unpublished`
 * `SERVER_HEALTHY_THRESHOLD`: The number of times an offline server needs to responds successfully for it to be considered online. Defaults to **1**. If you increase this number, you should decrease `POLL_INTERVAL`
 * `SERVER_UNHEALTHY_THRESHOLD`: The number of times an online server needs to responds unsuccessfully for it to be considered offline. Defaults to **2**. If you increase this number, you should decrease `POLL_INTERVAL`
+* `USE_UUID`: If this is set, Scalelite will generate a UUID for each added server instead of using the hostname.
 
 ### Redis Connection (`config/redis_store.yml`)
 

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -41,7 +41,10 @@ class Server < ApplicationRedisRecord
       raise RecordNotSaved.new('Cannot update id field', self) if id_changed?
 
       # Default values
-      self.id = SecureRandom.uuid if id.nil?
+      host = URI.parse(url).host.downcase
+      if id.nil?
+        self.id = ENV['USE_UUID'] ? SecureRandom.uuid : host
+      end
       self.online = false if online.nil?
 
       # Ignore load changes (would re-add to server_load set) unless enabled


### PR DESCRIPTION
When managing a larger cluster and wanting to take down specific hosts
or chunks, is it quite inconvenient to find out the specific IDs handed
out to servers in scalelite. Being able to use the domain names instead
would be much nicer.

While it is conceivable that multiple servers share the same domain
name, this is actually pretty unlikely. Usually, the domain name should
be unique and work just fine as identifier.

This patch switches to using the domain name as identifier by default.
If required for any reason, people can still switch to using UUIDs
though. Old IDs will, of course, stay valid.