### PR TITLE
Scan only BBB servers which are online and enabled in scalelite

### DIFF
--- a/lib/tasks/status.rake
+++ b/lib/tasks/status.rake
@@ -15,8 +15,8 @@ task status: :environment do
       video_streams = 0
       users_in_largest_meeting = 0
 
-      # Scan only enabled servers
-      if server.online
+      # Scan only enabled servers that are online
+      if server.online && server.enabled
         response = get_post_req(encode_bbb_uri('getMeetings', server.url, server.secret))
         meetings = response.xpath('/response/meetings/meeting')
 

--- a/lib/tasks/status.rake
+++ b/lib/tasks/status.rake
@@ -9,21 +9,26 @@ task status: :environment do
   servers_info = []
   Server.all.each do |server|
     begin
-      response = get_post_req(encode_bbb_uri('getMeetings', server.url, server.secret))
-      meetings = response.xpath('/response/meetings/meeting')
-
+      # Empty defaults
+      meetings = []
       server_users = 0
       video_streams = 0
       users_in_largest_meeting = 0
 
-      meetings.each do |meeting|
-        count = meeting.at_xpath('participantCount')
-        users = count.present? ? count.text.to_i : 0
-        server_users += users
-        users_in_largest_meeting = users if users > users_in_largest_meeting
+      # Scan only enabled servers
+      if server.online
+        response = get_post_req(encode_bbb_uri('getMeetings', server.url, server.secret))
+        meetings = response.xpath('/response/meetings/meeting')
 
-        streams = meeting.at_xpath('videoCount')
-        video_streams += streams.present? ? streams.text.to_i : 0
+        meetings.each do |meeting|
+          count = meeting.at_xpath('participantCount')
+          users = count.present? ? count.text.to_i : 0
+          server_users += users
+          users_in_largest_meeting = users if users > users_in_largest_meeting
+
+          streams = meeting.at_xpath('videoCount')
+          video_streams += streams.present? ? streams.text.to_i : 0
+        end
       end
     rescue StandardError
       # Set all values to 0 if request to server fails (server is offline)


### PR DESCRIPTION
We had an issue that our monitoring (which relies on rake status) failed after we disabled a lot (~300) of our BBB servers in scalelite without deleting them. rake status took a long time because every offline server produced a small timeout delay, and because of the large number they added up to a reasonable duration.

This can easily be prevented, if servers which are disabled or offline in scalelite are skipped (at least servers that are known to be offline should be skipped - by skipping disabled servers your stats are getting of a little bit, too)

